### PR TITLE
Escape values before rendering them in template.

### DIFF
--- a/meta/templatetags/meta.py
+++ b/meta/templatetags/meta.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from django import template
+from django.utils.html import escape
 
 register = template.Library()
 
@@ -10,22 +11,22 @@ def generic_prop(namespace, name, value):
     """
     Generic property setter that allows to create custom namespaced meta
     """
-    return '<meta property="%s:%s" content="%s">' % (namespace, name, value)
+    return custom_meta('property', '%s:%s' % (namespace, name), value)
 
 
 @register.simple_tag
 def og_prop(name, value):
-    return '<meta property="og:%s" content="%s">' % (name, value)
+    return custom_meta('property', 'og:%s' % name, value)
 
 
 @register.simple_tag
 def twitter_prop(name, value):
-    return '<meta name="twitter:%s" content="%s">' % (name, value)
+    return custom_meta('name', 'twitter:%s' % name, value)
 
 
 @register.simple_tag
 def googleplus_prop(name, value):
-    return '<meta itemprop="%s" content="%s">' % (name, value)
+    return custom_meta('itemprop', name, value)
 
 
 @register.simple_tag
@@ -34,28 +35,32 @@ def googleplus_html_scope(value):
     This is meant to be used as attribute to html / body or other tags to
     define schema.org type
     """
-    return ' itemscope itemtype="http://schema.org/%s" ' % value
+    return ' itemscope itemtype="http://schema.org/%s" ' % escape(value)
 
 
 @register.simple_tag
 def meta(name, value):
-    return '<meta name="%s" content="%s">' % (name, value)
+    return custom_meta('name', name, value)
+
 
 @register.simple_tag
-def custom_meta(name_key, name_value, content):
-    return '<meta %s="%s" content="%s">' % (name_key, name_value, content)
+def custom_meta(key, name, value):
+    return '<meta %s="%s" content="%s">' % (escape(key), escape(name), escape(value))
+
 
 @register.simple_tag
 def meta_list(name, lst):
     try:
-        return '<meta name="%s" content="%s">' % (name, ', '.join(lst))
+        return custom_meta('name', name, ', '.join(lst))
     except:
         return ''
+
 
 @register.simple_tag
 def meta_extras(extra_props):
     return ' '.join([meta(name, extra_props[name]) if extra_props[name] else ''
                      for name in extra_props])
+
 
 @register.simple_tag
 def custom_meta_extras(extra_custom_props):

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -16,10 +16,17 @@ class OgPropTestCase(unittest.TestCase):
             og_prop('type', 'website'),
             '<meta property="og:type" content="website">'
         )
+
     def test_generic_prop_basically_works(self):
         self.assertEqual(
             generic_prop('og', 'type', 'website'),
             '<meta property="og:type" content="website">'
+        )
+
+    def test_generic_prop_escapes_xss(self):
+        self.assertEqual(
+            generic_prop('og', 't"y&p<e', 'web&site'),
+            '<meta property="og:t&quot;y&amp;p&lt;e" content="web&amp;site">'
         )
 
 
@@ -30,12 +37,24 @@ class MetaTestCase(unittest.TestCase):
             '<meta name="description" content="Awesome website about ponies">'
         )
 
+    def test_meta_escapes_xss(self):
+        self.assertEqual(
+            meta('desc"rip&tion', 'Awesome website < about ponies'),
+            '<meta name="desc&quot;rip&amp;tion" content="Awesome website &lt; about ponies">'
+        )
+
 
 class CustomMetaTestCase(unittest.TestCase):
     def test_custom_meta_basically_works(self):
         self.assertEqual(
             custom_meta('property', 'foo', 'bar'),
             '<meta property="foo" content="bar">'
+        )
+
+    def test_custom_meta_escapes_xss(self):
+        self.assertEqual(
+            custom_meta('prop&erty', 'fo"o', 'b<ar'),
+            '<meta prop&amp;erty="fo&quot;o" content="b&lt;ar">'
         )
 
 
@@ -46,18 +65,30 @@ class TwitterPropTestCase(unittest.TestCase):
             '<meta name="twitter:foo" content="bar">'
         )
 
+    def test_twitter_escapes_xss(self):
+        self.assertEqual(
+            twitter_prop('fo"o', 'b<ar'),
+            '<meta name="twitter:fo&quot;o" content="b&lt;ar">'
+        )
+
 
 class GooglePlusPropTestcase(unittest.TestCase):
-    def test_google_plus_basically_wors(self):
+    def test_google_plus_basically_works(self):
         self.assertEqual(
             googleplus_prop('foo', 'bar'),
             '<meta itemprop="foo" content="bar">'
         )
-        
+
     def test_google_plus_scope_works(self):
         self.assertEqual(
             googleplus_html_scope('bar'),
             ' itemscope itemtype="http://schema.org/bar" '
+        )
+
+    def test_google_plus_escapes_xss(self):
+        self.assertEqual(
+            googleplus_prop('fo"o', 'b<ar'),
+            '<meta itemprop="fo&quot;o" content="b&lt;ar">'
         )
 
 
@@ -72,6 +103,12 @@ class MetaListTestCase(unittest.TestCase):
         self.assertEqual(
             meta_list('keywords', 12),
             ''
+        )
+
+    def test_meta_list_escapes_xss(self):
+        self.assertEqual(
+            meta_list('keywords', ['fo"o', 'bar', 'b<az']),
+            '<meta name="keywords" content="fo&quot;o, bar, b&lt;az">'
         )
 
 


### PR DESCRIPTION
I have realized the current template tags are not escaping special characters, which might result in XSS problems. I introduced escaping to `custom_meta` base method and refactored the code to reuse it.
