### PR TITLE
Added custom fb and twitter image capability

### DIFF
--- a/meta/templates/meta.html
+++ b/meta/templates/meta.html
@@ -9,7 +9,11 @@
 {% if meta.title %}{% og_prop 'title' meta.title %}{% endif %}
 {% if meta.url %}{% og_prop 'url' meta.url %}{% endif %}
 {% if meta.description %}{% og_prop 'description' meta.description %}{% endif %}
+{% if meta.facebook_image %}
+{% og_prop 'image' meta.facebook_image %}
+{% else %}
 {% if meta.image %}{% og_prop 'image' meta.image %}{% endif %}
+{% endif %}
 {% if meta.object_type %}{% og_prop 'type' meta.object_type %}{% endif %}
 {% if meta.site_name %}{% og_prop 'site_name'  meta.site_name %}{% endif %}
 {% if meta.locale %}{% og_prop 'locale'  meta.locale%}{% endif %}
@@ -18,7 +22,11 @@
 {% if meta.title %}{% twitter_prop 'title' meta.title %}{% endif %}
 {% if meta.url %}{% twitter_prop 'url' meta.url %}{% endif %}
 {% if meta.description %}{% twitter_prop 'description' meta.description %}{% endif %}
+{% if meta.twitter_image %}
+{% twitter_prop 'image' meta.twitter_image %}
+{% else %}
 {% if meta.image %}{% twitter_prop 'image' meta.image %}{% endif %}
+{% endif %}
 {% if meta.twitter_site %}{% twitter_prop 'site' meta.twitter_site %}{% endif %}
 {% endif %}
 {% if meta.use_googleplus %}

--- a/meta/views.py
+++ b/meta/views.py
@@ -28,6 +28,8 @@ class Meta(object):
         self.use_og = kwargs.get('use_og', settings.USE_OG_PROPERTIES)
         self.use_twitter = kwargs.get('use_twitter', settings.USE_TWITTER_PROPERTIES)
         self.use_googleplus = kwargs.get('use_googleplus', settings.USE_GOOGLEPLUS_PROPERTIES)
+        self.twitter_image = kwargs.get('twitter_image')
+        self.facebook_image = kwargs.get('facebook_image')
 
     def get_domain(self):
         if self.use_sites:
@@ -115,6 +117,8 @@ class MetadataMixin(object):
     site_name = None
     twitter_site = None
     locale = None
+    twitter_image = None
+    facebook_image = None
     use_sites = settings.USE_SITES
     use_og = settings.USE_OG_PROPERTIES
 
@@ -160,6 +164,12 @@ class MetadataMixin(object):
     def get_meta_locale(self, context={}):
         return self.locale
 
+    def get_meta_twitter_image(self, context={}):
+        return self.twitter_image
+
+    def get_meta_facebook_image(self, context={}):
+        return self.facebook_image
+
     def get_context_data(self, **kwargs):
         context = super(MetadataMixin, self).get_context_data(**kwargs)
         context['meta'] = self.get_meta_class()(
@@ -176,5 +186,7 @@ class MetadataMixin(object):
             site_name=self.get_meta_site_name(context=context),
             twitter_site=self.get_meta_twitter_site(context=context),
             locale=self.get_meta_locale(context=context),
+            twitter_image=self.get_meta_twitter_image(context=context),
+            facebook_image=self.get_meta_facebook_image(context=context),
         )
         return context


### PR DESCRIPTION
@cansin @murataydos @eedeebee Can you please review this PR and it is a little bit urgent for BF.

What I am doing is putting custom facebook and twitter image urls into `head` of featured page. Before that, we were not able to put custom images for facebook and twitter separately. They were using default `image` in `meta` . It will be really good if you can help about release of this lib.